### PR TITLE
Added option to override the output layer name

### DIFF
--- a/cmd/tegola/main.go
+++ b/cmd/tegola/main.go
@@ -42,6 +42,7 @@ type Map struct {
 	Bounds      []float64  `toml:"bounds"`
 	Center      [3]float64 `toml:"center"`
 	Layers      []struct {
+		Name          string      `toml:"name"` // optional, otherwise inferred from ProviderLayer
 		ProviderLayer string      `toml:"provider_layer"`
 		MinZoom       int         `toml:"min_zoom"`
 		MaxZoom       int         `toml:"max_zoom"`
@@ -186,14 +187,18 @@ func initMaps(maps []Map, providers map[string]mvt.Provider) error {
 					return fmt.Errorf("'default_tags' for 'provider_layer' (%v) should be a TOML table", l.ProviderLayer)
 				}
 			}
+			if len(l.Name) == 0 {
+				l.Name = providerLayer[1]
+			}
 
 			//	add our layer to our layers slice
 			serverMap.Layers = append(serverMap.Layers, server.Layer{
-				Name:        providerLayer[1],
-				MinZoom:     l.MinZoom,
-				MaxZoom:     l.MaxZoom,
-				Provider:    provider,
-				DefaultTags: defaultTags,
+				Name:          l.Name,
+				ProviderLayer: providerLayer[1],
+				MinZoom:       l.MinZoom,
+				MaxZoom:       l.MaxZoom,
+				Provider:      provider,
+				DefaultTags:   defaultTags,
 			})
 		}
 

--- a/mvt/provider.go
+++ b/mvt/provider.go
@@ -5,7 +5,7 @@ import "github.com/terranodo/tegola"
 //Provider is the mechinism by which the system talks to different data providers.
 type Provider interface {
 	// MVTLayer returns a layer object based
-	MVTLayer(layerName string, tile tegola.Tile, tags map[string]interface{}) (*Layer, error)
+	MVTLayer(providerLayerName string, outputLayerName string, tile tegola.Tile, tags map[string]interface{}) (*Layer, error)
 	// LayerNames returns a list of layer name the Provider knows about.
 	LayerNames() []string
 }

--- a/mvt/provider.go
+++ b/mvt/provider.go
@@ -5,7 +5,7 @@ import "github.com/terranodo/tegola"
 //Provider is the mechinism by which the system talks to different data providers.
 type Provider interface {
 	// MVTLayer returns a layer object based
-	MVTLayer(providerLayerName string, outputLayerName string, tile tegola.Tile, tags map[string]interface{}) (*Layer, error)
+	MVTLayer(providerLayerName string, tile tegola.Tile, tags map[string]interface{}) (*Layer, error)
 	// LayerNames returns a list of layer name the Provider knows about.
 	LayerNames() []string
 }

--- a/mvt/provider/provider.go
+++ b/mvt/provider/provider.go
@@ -29,7 +29,7 @@ func Drivers() (l []string) {
 	if providers == nil {
 		return l
 	}
-	for k, _ := range providers {
+	for k := range providers {
 		l = append(l, k)
 	}
 	return l

--- a/provider/postgis/postgis.go
+++ b/provider/postgis/postgis.go
@@ -342,11 +342,11 @@ func transfromVal(valType pgx.Oid, val interface{}) (interface{}, error) {
 	}
 }
 
-func (p Provider) MVTLayer(layerName string, tile tegola.Tile, tags map[string]interface{}) (layer *mvt.Layer, err error) {
+func (p Provider) MVTLayer(providerLayerName string, outputLayerName string, tile tegola.Tile, tags map[string]interface{}) (layer *mvt.Layer, err error) {
 
-	plyr, ok := p.layers[layerName]
+	plyr, ok := p.layers[providerLayerName]
 	if !ok {
-		return nil, fmt.Errorf("Don't know of the layer %v", layerName)
+		return nil, fmt.Errorf("Don't know of the layer %v", providerLayerName)
 	}
 
 	textent := tile.BoundingBox()
@@ -380,7 +380,7 @@ func (p Provider) MVTLayer(layerName string, tile tegola.Tile, tags map[string]i
 	var geobytes []byte
 
 	layer = new(mvt.Layer)
-	layer.Name = layerName
+	layer.Name = outputLayerName
 	var count int
 	var didEnd bool
 	if strings.Contains(os.Getenv("SQL_DEBUG"), "EXECUTE_SQL") {
@@ -403,17 +403,17 @@ func (p Provider) MVTLayer(layerName string, tile tegola.Tile, tags map[string]i
 			switch fdescs[i].Name {
 			case plyr.GeomFieldName:
 				if geobytes, ok = v.([]byte); !ok {
-					return nil, fmt.Errorf("Was unable to convert geometry field(%v) into bytes for layer %v.", plyr.GeomFieldName, layerName)
+					return nil, fmt.Errorf("Was unable to convert geometry field(%v) into bytes for layer %v.", plyr.GeomFieldName, providerLayerName)
 				}
 				if geom, err = wkb.DecodeBytes(geobytes); err != nil {
-					return nil, fmt.Errorf("Was unable to decode geometry field(%v) into wkb for layer %v.", plyr.GeomFieldName, layerName)
+					return nil, fmt.Errorf("Was unable to decode geometry field(%v) into wkb for layer %v.", plyr.GeomFieldName, providerLayerName)
 				}
 				// TODO: Need to move this from being the responsiblity of the provider to the responsibility of the feature. But that means a feature should know
 				// how the points are encoded.
 				if plyr.SRID != DefaultSRID {
 					// We need to convert our points to Webmercator.
 					if geom, err = basic.ToWebMercator(plyr.SRID, geom); err != nil {
-						return nil, fmt.Errorf("Was unable to transform geometry to webmercator from SRID(%v) for layer %v.", plyr.SRID, layerName)
+						return nil, fmt.Errorf("Was unable to transform geometry to webmercator from SRID(%v) for layer %v.", plyr.SRID, providerLayerName)
 					}
 				}
 			case plyr.IDFieldName:
@@ -439,7 +439,7 @@ func (p Provider) MVTLayer(layerName string, tile tegola.Tile, tags map[string]i
 				case uint32:
 					gid = uint64(aval)
 				default:
-					return nil, fmt.Errorf("Unable to convert geometry ID field(%v) into a uint64 for layer %v", plyr.IDFieldName, layerName)
+					return nil, fmt.Errorf("Unable to convert geometry ID field(%v) into a uint64 for layer %v", plyr.IDFieldName, providerLayerName)
 				}
 			default:
 				if vals[i] == nil {

--- a/provider/postgis/postgis.go
+++ b/provider/postgis/postgis.go
@@ -360,11 +360,11 @@ func (p Provider) MVTLayer(providerLayerName string, tile tegola.Tile, tags map[
 	}
 	minPt, ok := minGeo.(*basic.Point)
 	if !ok {
-		return nil, fmt.Errorf("Expected Point, got %t %v", minGeo)
+		return nil, fmt.Errorf("Expected Point, got %t %v", minGeo, minGeo)
 	}
 	maxPt, ok := maxGeo.(*basic.Point)
 	if !ok {
-		return nil, fmt.Errorf("Expected Point, got %t %v", maxGeo)
+		return nil, fmt.Errorf("Expected Point, got %t %v", maxGeo, maxGeo)
 	}
 
 	bbox := fmt.Sprintf("ST_MakeEnvelope(%v,%v,%v,%v,%v)", minPt.X(), minPt.Y(), maxPt.X(), maxPt.Y(), plyr.SRID)

--- a/provider/postgis/postgis.go
+++ b/provider/postgis/postgis.go
@@ -342,7 +342,7 @@ func transfromVal(valType pgx.Oid, val interface{}) (interface{}, error) {
 	}
 }
 
-func (p Provider) MVTLayer(providerLayerName string, outputLayerName string, tile tegola.Tile, tags map[string]interface{}) (layer *mvt.Layer, err error) {
+func (p Provider) MVTLayer(providerLayerName string, tile tegola.Tile, tags map[string]interface{}) (layer *mvt.Layer, err error) {
 
 	plyr, ok := p.layers[providerLayerName]
 	if !ok {
@@ -380,7 +380,6 @@ func (p Provider) MVTLayer(providerLayerName string, outputLayerName string, til
 	var geobytes []byte
 
 	layer = new(mvt.Layer)
-	layer.Name = outputLayerName
 	var count int
 	var didEnd bool
 	if strings.Contains(os.Getenv("SQL_DEBUG"), "EXECUTE_SQL") {

--- a/provider/postgis/postgis_test.go
+++ b/provider/postgis/postgis_test.go
@@ -39,7 +39,7 @@ func TestNewProvider(t *testing.T) {
 		X: 12451,
 		Y: 18527,
 	}
-	l, err := p.MVTLayer("buildings", tile, map[string]interface{}{"class": "park"})
+	l, err := p.MVTLayer("buildings", "buildings", tile, map[string]interface{}{"class": "park"})
 	if err != nil {
 		t.Errorf("Failed to create mvt layer. %v", err)
 		return

--- a/provider/postgis/postgis_test.go
+++ b/provider/postgis/postgis_test.go
@@ -39,7 +39,7 @@ func TestNewProvider(t *testing.T) {
 		X: 12451,
 		Y: 18527,
 	}
-	l, err := p.MVTLayer("buildings", "buildings", tile, map[string]interface{}{"class": "park"})
+	l, err := p.MVTLayer("buildings", tile, map[string]interface{}{"class": "park"})
 	if err != nil {
 		t.Errorf("Failed to create mvt layer. %v", err)
 		return

--- a/server/handle_capabilities.go
+++ b/server/handle_capabilities.go
@@ -22,10 +22,11 @@ type CapabilitiesMap struct {
 }
 
 type CapabilitiesLayer struct {
-	Name    string   `json:"name"`
-	Tiles   []string `json:"tiles"`
-	MinZoom int      `json:"minzoom"`
-	MaxZoom int      `json:"maxzoom"`
+	Name          string   `json:"name"`
+	ProviderLayer string   `json:"provider_layer"`
+	Tiles         []string `json:"tiles"`
+	MinZoom       int      `json:"minzoom"`
+	MaxZoom       int      `json:"maxzoom"`
 }
 
 type HandleCapabilities struct{}
@@ -74,7 +75,8 @@ func (req HandleCapabilities) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 			for _, layer := range m.Layers {
 				//	build the layer details
 				cLayer := CapabilitiesLayer{
-					Name: layer.Name,
+					Name:          layer.Name,
+					ProviderLayer: layer.ProviderLayer,
 					Tiles: []string{
 						fmt.Sprintf("%v%v/maps/%v/%v/{z}/{x}/{y}.pbf", rScheme, r.Host, m.Name, layer.Name),
 					},

--- a/server/handle_map_layer_zxy.go
+++ b/server/handle_map_layer_zxy.go
@@ -161,7 +161,8 @@ func (req HandleMapLayerZXY) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					defer wg.Done()
 
 					//	fetch layer from data provider
-					mvtLayer, err := l.Provider.MVTLayer(l.ProviderLayer, l.Name, tile, l.DefaultTags)
+					mvtLayer, err := l.Provider.MVTLayer(l.ProviderLayer, tile, l.DefaultTags)
+					mvtLayer.Name = l.Name
 					if err != nil {
 						errMsg := fmt.Sprintf("Error Getting MVTLayer: %v", err)
 						log.Println(errMsg)

--- a/server/handle_map_layer_zxy.go
+++ b/server/handle_map_layer_zxy.go
@@ -161,7 +161,7 @@ func (req HandleMapLayerZXY) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					defer wg.Done()
 
 					//	fetch layer from data provider
-					mvtLayer, err := l.Provider.MVTLayer(l.Name, tile, l.DefaultTags)
+					mvtLayer, err := l.Provider.MVTLayer(l.ProviderLayer, l.Name, tile, l.DefaultTags)
 					if err != nil {
 						errMsg := fmt.Sprintf("Error Getting MVTLayer: %v", err)
 						log.Println(errMsg)

--- a/server/handle_map_zxy.go
+++ b/server/handle_map_zxy.go
@@ -146,7 +146,7 @@ func (req HandleMapZXY) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					defer wg.Done()
 
 					//	fetch layer from data provider
-					mvtLayer, err := l.Provider.MVTLayer(l.Name, tile, l.DefaultTags)
+					mvtLayer, err := l.Provider.MVTLayer(l.ProviderLayer, l.Name, tile, l.DefaultTags)
 					if err != nil {
 						log.Printf("Error Getting MVTLayer: %v", err)
 						http.Error(w, fmt.Sprintf("Error Getting MVTLayer: %v", err.Error()), http.StatusBadRequest)

--- a/server/handle_map_zxy.go
+++ b/server/handle_map_zxy.go
@@ -146,7 +146,8 @@ func (req HandleMapZXY) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					defer wg.Done()
 
 					//	fetch layer from data provider
-					mvtLayer, err := l.Provider.MVTLayer(l.ProviderLayer, l.Name, tile, l.DefaultTags)
+					mvtLayer, err := l.Provider.MVTLayer(l.ProviderLayer, tile, l.DefaultTags)
+					mvtLayer.Name = l.Name
 					if err != nil {
 						log.Printf("Error Getting MVTLayer: %v", err)
 						http.Error(w, fmt.Sprintf("Error Getting MVTLayer: %v", err.Error()), http.StatusBadRequest)

--- a/server/map.go
+++ b/server/map.go
@@ -49,9 +49,10 @@ func (m *Map) FilterLayersByName(name string) (filteredLayers []Layer) {
 }
 
 type Layer struct {
-	Name    string
-	MinZoom int
-	MaxZoom int
+	Name          string // if none is set, it will be inferred from ProviderLayer
+	ProviderLayer string
+	MinZoom       int
+	MaxZoom       int
 	//	instantiated provider
 	Provider mvt.Provider
 	//	default tags to include when encoding the layer. provider tags take precedence

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -15,7 +15,7 @@ const (
 
 type testMVTProvider struct{}
 
-func (tp *testMVTProvider) MVTLayer(layerName string, tile tegola.Tile, tags map[string]interface{}) (*mvt.Layer, error) {
+func (tp *testMVTProvider) MVTLayer(providerLayerName string, layerName string, tile tegola.Tile, tags map[string]interface{}) (*mvt.Layer, error) {
 	var layer mvt.Layer
 
 	return &layer, nil

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -15,7 +15,7 @@ const (
 
 type testMVTProvider struct{}
 
-func (tp *testMVTProvider) MVTLayer(providerLayerName string, layerName string, tile tegola.Tile, tags map[string]interface{}) (*mvt.Layer, error) {
+func (tp *testMVTProvider) MVTLayer(providerLayerName string, tile tegola.Tile, tags map[string]interface{}) (*mvt.Layer, error) {
 	var layer mvt.Layer
 
 	return &layer, nil


### PR DESCRIPTION
An attempt on building the issue discussed in https://github.com/terranodo/tegola/issues/94.

What I did here is adding the possibility to specify an additional `name` for each `maps.layer`. If none is specified, it is ignored and generated from `provider_layer` as it was. Existing configurations are unaffected this way.

Because the data source name was also used as the output name in the tile, I changed the `MVTLayer ` method to have to be able to take distinct strings.

I tried to make the changes as simple as possible, I hope this is acceptable for you. If you have any feedback, I'd love to hear it.