### PR TITLE
Fix misspellings reported in #105.

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ srid = 3857             # The default srid for this provider. If not provided it
 	name = "rivers" 					# will be encoded as the layer name in the tile
 	geometry_fieldname = "geom"			# geom field. default is geom
 	id_fieldname = "gid"				# geom id field. default is gid
-	# Custom sql to be used for this layer. Note: that the geometery field is wraped
+	# Custom sql to be used for this layer. Note: that the geometry field is wraped
 	# in a ST_AsBinary, as tegola only understand wkb.
 	sql = """
 		SELECT

--- a/basic/line.go
+++ b/basic/line.go
@@ -3,7 +3,7 @@ package basic
 import "github.com/terranodo/tegola"
 
 // Line is a basic line type which is made up of two or more points that don't
-// interect.
+// intersect.
 // TODO: We don't really check to make sure the points don't intersect.
 type Line []Point
 

--- a/basic/polygon.go
+++ b/basic/polygon.go
@@ -26,7 +26,7 @@ type MultiPolygon []Polygon
 // Just to make basic collection only usable with basic types.
 func (MultiPolygon) basicType() {}
 
-// Polygons retuns the polygons that make up the set.
+// Polygons returns the polygons that make up the set.
 func (mp *MultiPolygon) Polygons() (polygons []tegola.Polygon) {
 	polygons = make([]tegola.Polygon, 0, len(*mp))
 	for i := range *mp {

--- a/mvt/feature.go
+++ b/mvt/feature.go
@@ -130,7 +130,7 @@ type cursor struct {
 	tile tegola.BoundingBox
 
 	// The extent — it is an int, but to make computations easier and not lose precision
-	// Untill we convert the ∆'s to int32.
+	// Until we convert the ∆'s to int32.
 	extent float64
 
 	// These values are cached

--- a/mvt/feature_test.go
+++ b/mvt/feature_test.go
@@ -190,7 +190,7 @@ func TestNewFeature(t *testing.T) {
 		if len(tcase.expected) <= 0 {
 			continue
 		}
-		// TOOD test to make sure we got the correct feature
+		// TODO test to make sure we got the correct feature
 
 	}
 }

--- a/mvt/tile.go
+++ b/mvt/tile.go
@@ -34,7 +34,7 @@ func (t *Tile) Layers() (l []Layer) {
 }
 
 //VTile returns a tile object according to the Google Protobuff def. This function
-// does the hard work of converting everthing to the standard.
+// does the hard work of converting everything to the standard.
 func (t *Tile) VTile(extent tegola.BoundingBox) (vt *vectorTile.Tile, err error) {
 	vt = new(vectorTile.Tile)
 	for _, l := range t.layers {

--- a/provider/postgis/postgis.go
+++ b/provider/postgis/postgis.go
@@ -24,7 +24,7 @@ type layer struct {
 	SQL string
 	// The ID field name, this will default to 'gid' if not set to something other then empty string.
 	IDFieldName string
-	// The Geometery field name, this will default to 'geom' if not set to soemthing other then empty string.
+	// The Geometry field name, this will default to 'geom' if not set to something other then empty string.
 	GeomFieldName string
 	// The SRID that the data in the table is stored in. This will default to WebMercator
 	SRID int
@@ -34,7 +34,7 @@ type layer struct {
 type Provider struct {
 	config pgx.ConnPoolConfig
 	pool   *pgx.ConnPool
-	layers map[string]layer // map of layer name and corrosponding sql
+	layers map[string]layer // map of layer name and corresponding sql
 	srid   int
 }
 
@@ -408,7 +408,7 @@ func (p Provider) MVTLayer(layerName string, tile tegola.Tile, tags map[string]i
 				if geom, err = wkb.DecodeBytes(geobytes); err != nil {
 					return nil, fmt.Errorf("Was unable to decode geometry field(%v) into wkb for layer %v.", plyr.GeomFieldName, layerName)
 				}
-				// TODO: Need to move this from being the responsiblity of the provider to the responsibility of the feature. But that means a feature should know
+				// TODO: Need to move this from being the responsibility of the provider to the responsibility of the feature. But that means a feature should know
 				// how the points are encoded.
 				if plyr.SRID != DefaultSRID {
 					// We need to convert our points to Webmercator.

--- a/server/handle_map_capabilities.go
+++ b/server/handle_map_capabilities.go
@@ -84,7 +84,7 @@ func (req HandleMapCapabilities) ServeHTTP(w http.ResponseWriter, r *http.Reques
 			Data:        make([]string, 0),
 		}
 
-		//	determing the min and max zoom for this map
+		//	determining the min and max zoom for this map
 		for i, l := range m.Layers {
 			//	set our min and max using the first layer
 			if i == 0 {

--- a/wkb/collection.go
+++ b/wkb/collection.go
@@ -18,7 +18,7 @@ WKBGeometry      wkbGeometries[num_wkbGeometries]
 // Collection is a collection of geometries.
 type Collection []Geometry
 
-// Type returns the type number of this geometery, by the spec it's 7.
+// Type returns the type number of this geometry, by the spec it's 7.
 func (Collection) Type() uint32 {
 	return GeoGeometryCollection
 }


### PR DESCRIPTION
Additionally, several misspellings of 'geometery' -> 'geometry'.