### PR TITLE
Issue199 host name fixup

### DIFF
--- a/server/handle_capabilities_test.go
+++ b/server/handle_capabilities_test.go
@@ -19,11 +19,14 @@ func TestHandleCapabilities(t *testing.T) {
 	testcases := []struct {
 		handler    http.Handler
 		hostname   string
+		port       string
 		uri        string
 		uriPattern string
 		reqMethod  string
 		expected   server.Capabilities
 	}{
+		// With empty hostname and no port specified in config, urls should have host:port matching
+		//	request uri.
 		{
 			handler:    server.HandleCapabilities{},
 			hostname:   "",
@@ -64,9 +67,11 @@ func TestHandleCapabilities(t *testing.T) {
 				},
 			},
 		},
+		// With hostname set and port set to "none" in config, urls should have host "cdn.tegola.io"
 		{
 			handler:    server.HandleCapabilities{},
 			hostname:   "cdn.tegola.io",
+			port:       "none", // Set to none or port 8080 from uri will be used.
 			uri:        "http://localhost:8080/capabilities?debug=true",
 			uriPattern: "/capabilities",
 			reqMethod:  "GET",
@@ -120,12 +125,129 @@ func TestHandleCapabilities(t *testing.T) {
 				},
 			},
 		},
+		// With hostname set and port unset in config, urls should have host from config and
+		// 	port from uri: "cdn.tegola.io:8080"
+		{
+			handler:    server.HandleCapabilities{},
+			hostname:   "cdn.tegola.io",
+			uri:        "http://localhost:8080/capabilities?debug=true",
+			uriPattern: "/capabilities",
+			reqMethod:  "GET",
+			expected: server.Capabilities{
+				Version: serverVersion,
+				Maps: []server.CapabilitiesMap{
+					{
+						Name:         "test-map",
+						Attribution:  "test attribution",
+						Center:       [3]float64{1.0, 2.0, 3.0},
+						Capabilities: "http://cdn.tegola.io:8080/capabilities/test-map.json?debug=true",
+						Tiles: []string{
+							"http://cdn.tegola.io:8080/maps/test-map/{z}/{x}/{y}.pbf?debug=true",
+						},
+						Layers: []server.CapabilitiesLayer{
+
+							{
+								Name: testLayer1.MVTName(),
+								Tiles: []string{
+									fmt.Sprintf("http://cdn.tegola.io:8080/maps/test-map/%v/{z}/{x}/{y}.pbf?debug=true", testLayer1.MVTName()),
+								},
+								MinZoom: testLayer1.MinZoom,
+								MaxZoom: testLayer3.MaxZoom, //	layer 1 and layer 3 share a name in our test so the zoom range includes the entire zoom range
+							},
+							{
+								Name: "test-layer-2-name",
+								Tiles: []string{
+									fmt.Sprintf("http://cdn.tegola.io:8080/maps/test-map/%v/{z}/{x}/{y}.pbf?debug=true", testLayer2.MVTName()),
+								},
+								MinZoom: testLayer2.MinZoom,
+								MaxZoom: testLayer2.MaxZoom,
+							},
+							{
+								Name: "debug-tile-outline",
+								Tiles: []string{
+									"http://cdn.tegola.io:8080/maps/test-map/debug-tile-outline/{z}/{x}/{y}.pbf?debug=true",
+								},
+								MinZoom: 0,
+								MaxZoom: server.MaxZoom,
+							},
+							{
+								Name: "debug-tile-center",
+								Tiles: []string{
+									"http://cdn.tegola.io:8080/maps/test-map/debug-tile-center/{z}/{x}/{y}.pbf?debug=true",
+								},
+								MinZoom: 0,
+								MaxZoom: server.MaxZoom,
+							},
+						},
+					},
+				},
+			},
+		},
+		// With hostname set in config, port unset in config, and no port in request uri,
+		//	 urls should have host from config and no port: "cdn.tegola.io"
+		{
+			handler:    server.HandleCapabilities{},
+			hostname:   "cdn.tegola.io",
+			uri:        "http://localhost/capabilities?debug=true",
+			uriPattern: "/capabilities",
+			reqMethod:  "GET",
+			expected: server.Capabilities{
+				Version: serverVersion,
+				Maps: []server.CapabilitiesMap{
+					{
+						Name:         "test-map",
+						Attribution:  "test attribution",
+						Center:       [3]float64{1.0, 2.0, 3.0},
+						Capabilities: "http://cdn.tegola.io/capabilities/test-map.json?debug=true",
+						Tiles: []string{
+							"http://cdn.tegola.io/maps/test-map/{z}/{x}/{y}.pbf?debug=true",
+						},
+						Layers: []server.CapabilitiesLayer{
+
+							{
+								Name: testLayer1.MVTName(),
+								Tiles: []string{
+									fmt.Sprintf("http://cdn.tegola.io/maps/test-map/%v/{z}/{x}/{y}.pbf?debug=true", testLayer1.MVTName()),
+								},
+								MinZoom: testLayer1.MinZoom,
+								MaxZoom: testLayer3.MaxZoom, //	layer 1 and layer 3 share a name in our test so the zoom range includes the entire zoom range
+							},
+							{
+								Name: "test-layer-2-name",
+								Tiles: []string{
+									fmt.Sprintf("http://cdn.tegola.io/maps/test-map/%v/{z}/{x}/{y}.pbf?debug=true", testLayer2.MVTName()),
+								},
+								MinZoom: testLayer2.MinZoom,
+								MaxZoom: testLayer2.MaxZoom,
+							},
+							{
+								Name: "debug-tile-outline",
+								Tiles: []string{
+									"http://cdn.tegola.io/maps/test-map/debug-tile-outline/{z}/{x}/{y}.pbf?debug=true",
+								},
+								MinZoom: 0,
+								MaxZoom: server.MaxZoom,
+							},
+							{
+								Name: "debug-tile-center",
+								Tiles: []string{
+									"http://cdn.tegola.io/maps/test-map/debug-tile-center/{z}/{x}/{y}.pbf?debug=true",
+								},
+								MinZoom: 0,
+								MaxZoom: server.MaxZoom,
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for i, test := range testcases {
 		var err error
 
 		server.HostName = test.hostname
+		server.Port = test.port
 
 		//	setup a new router. this handles parsing our URL wildcards (i.e. :map_name, :z, :x, :y)
 		router := httptreemux.New()

--- a/server/handle_capabilities_test.go
+++ b/server/handle_capabilities_test.go
@@ -125,12 +125,10 @@ func TestHandleCapabilities(t *testing.T) {
 				},
 			},
 		},
-		// With hostname set and port unset in config, urls should have host from config and
-		// 	port from uri: "cdn.tegola.io:8080"
 		{
 			handler:    server.HandleCapabilities{},
-			hostname:   "cdn.tegola.io",
-			uri:        "http://localhost:8080/capabilities?debug=true",
+			hostname:   "",
+			uri:        "http://localhost:8080/capabilities",
 			uriPattern: "/capabilities",
 			reqMethod:  "GET",
 			expected: server.Capabilities{
@@ -140,43 +138,27 @@ func TestHandleCapabilities(t *testing.T) {
 						Name:         "test-map",
 						Attribution:  "test attribution",
 						Center:       [3]float64{1.0, 2.0, 3.0},
-						Capabilities: "http://cdn.tegola.io:8080/capabilities/test-map.json?debug=true",
+						Bounds:       [4]float64{-180.0, -85.0511, 180.0, 85.0511},
+						Capabilities: "http://localhost:8080/capabilities/test-map.json",
 						Tiles: []string{
-							"http://cdn.tegola.io:8080/maps/test-map/{z}/{x}/{y}.pbf?debug=true",
+							"http://localhost:8080/maps/test-map/{z}/{x}/{y}.pbf",
 						},
 						Layers: []server.CapabilitiesLayer{
-
 							{
 								Name: testLayer1.MVTName(),
 								Tiles: []string{
-									fmt.Sprintf("http://cdn.tegola.io:8080/maps/test-map/%v/{z}/{x}/{y}.pbf?debug=true", testLayer1.MVTName()),
+									fmt.Sprintf("http://localhost:8080/maps/test-map/%v/{z}/{x}/{y}.pbf", testLayer1.MVTName()),
 								},
 								MinZoom: testLayer1.MinZoom,
 								MaxZoom: testLayer3.MaxZoom, //	layer 1 and layer 3 share a name in our test so the zoom range includes the entire zoom range
 							},
 							{
-								Name: "test-layer-2-name",
+								Name: testLayer2.MVTName(),
 								Tiles: []string{
-									fmt.Sprintf("http://cdn.tegola.io:8080/maps/test-map/%v/{z}/{x}/{y}.pbf?debug=true", testLayer2.MVTName()),
+									fmt.Sprintf("http://localhost:8080/maps/test-map/%v/{z}/{x}/{y}.pbf", testLayer2.MVTName()),
 								},
 								MinZoom: testLayer2.MinZoom,
 								MaxZoom: testLayer2.MaxZoom,
-							},
-							{
-								Name: "debug-tile-outline",
-								Tiles: []string{
-									"http://cdn.tegola.io:8080/maps/test-map/debug-tile-outline/{z}/{x}/{y}.pbf?debug=true",
-								},
-								MinZoom: 0,
-								MaxZoom: server.MaxZoom,
-							},
-							{
-								Name: "debug-tile-center",
-								Tiles: []string{
-									"http://cdn.tegola.io:8080/maps/test-map/debug-tile-center/{z}/{x}/{y}.pbf?debug=true",
-								},
-								MinZoom: 0,
-								MaxZoom: server.MaxZoom,
 							},
 						},
 					},
@@ -188,6 +170,7 @@ func TestHandleCapabilities(t *testing.T) {
 		{
 			handler:    server.HandleCapabilities{},
 			hostname:   "cdn.tegola.io",
+			port:       "none", // Set to none or port 8080 from uri will be used.
 			uri:        "http://localhost/capabilities?debug=true",
 			uriPattern: "/capabilities",
 			reqMethod:  "GET",
@@ -198,12 +181,28 @@ func TestHandleCapabilities(t *testing.T) {
 						Name:         "test-map",
 						Attribution:  "test attribution",
 						Center:       [3]float64{1.0, 2.0, 3.0},
+						Bounds:       [4]float64{-180.0, -85.0511, 180.0, 85.0511},
 						Capabilities: "http://cdn.tegola.io/capabilities/test-map.json?debug=true",
 						Tiles: []string{
 							"http://cdn.tegola.io/maps/test-map/{z}/{x}/{y}.pbf?debug=true",
 						},
 						Layers: []server.CapabilitiesLayer{
-
+							{
+								Name: "debug-tile-outline",
+								Tiles: []string{
+									"http://cdn.tegola.io/maps/test-map/debug-tile-outline/{z}/{x}/{y}.pbf?debug=true",
+								},
+								MinZoom: 0,
+								MaxZoom: atlas.MaxZoom,
+							},
+							{
+								Name: "debug-tile-center",
+								Tiles: []string{
+									"http://cdn.tegola.io/maps/test-map/debug-tile-center/{z}/{x}/{y}.pbf?debug=true",
+								},
+								MinZoom: 0,
+								MaxZoom: atlas.MaxZoom,
+							},
 							{
 								Name: testLayer1.MVTName(),
 								Tiles: []string{
@@ -220,21 +219,63 @@ func TestHandleCapabilities(t *testing.T) {
 								MinZoom: testLayer2.MinZoom,
 								MaxZoom: testLayer2.MaxZoom,
 							},
+						},
+					},
+				},
+			},
+		},
+		// With hostname set and port unset in config, urls should have host from config and
+		// 	port from uri: "cdn.tegola.io:8080"
+		{
+			handler:    server.HandleCapabilities{},
+			hostname:   "cdn.tegola.io",
+			uri:        "http://localhost:8080/capabilities?debug=true",
+			uriPattern: "/capabilities",
+			reqMethod:  "GET",
+			expected: server.Capabilities{
+				Version: serverVersion,
+				Maps: []server.CapabilitiesMap{
+					{
+						Name:         "test-map",
+						Attribution:  "test attribution",
+						Center:       [3]float64{1.0, 2.0, 3.0},
+						Bounds:       [4]float64{-180.0, -85.0511, 180.0, 85.0511},
+						Capabilities: "http://cdn.tegola.io:8080/capabilities/test-map.json?debug=true",
+						Tiles: []string{
+							"http://cdn.tegola.io:8080/maps/test-map/{z}/{x}/{y}.pbf?debug=true",
+						},
+						Layers: []server.CapabilitiesLayer{
 							{
 								Name: "debug-tile-outline",
 								Tiles: []string{
-									"http://cdn.tegola.io/maps/test-map/debug-tile-outline/{z}/{x}/{y}.pbf?debug=true",
+									"http://cdn.tegola.io:8080/maps/test-map/debug-tile-outline/{z}/{x}/{y}.pbf?debug=true",
 								},
 								MinZoom: 0,
-								MaxZoom: server.MaxZoom,
+								MaxZoom: atlas.MaxZoom,
 							},
 							{
 								Name: "debug-tile-center",
 								Tiles: []string{
-									"http://cdn.tegola.io/maps/test-map/debug-tile-center/{z}/{x}/{y}.pbf?debug=true",
+									"http://cdn.tegola.io:8080/maps/test-map/debug-tile-center/{z}/{x}/{y}.pbf?debug=true",
 								},
 								MinZoom: 0,
-								MaxZoom: server.MaxZoom,
+								MaxZoom: atlas.MaxZoom,
+							},
+							{
+								Name: testLayer1.MVTName(),
+								Tiles: []string{
+									fmt.Sprintf("http://cdn.tegola.io:8080/maps/test-map/%v/{z}/{x}/{y}.pbf?debug=true", testLayer1.MVTName()),
+								},
+								MinZoom: testLayer1.MinZoom,
+								MaxZoom: testLayer3.MaxZoom, //	layer 1 and layer 3 share a name in our test so the zoom range includes the entire zoom range
+							},
+							{
+								Name: "test-layer-2-name",
+								Tiles: []string{
+									fmt.Sprintf("http://cdn.tegola.io:8080/maps/test-map/%v/{z}/{x}/{y}.pbf?debug=true", testLayer2.MVTName()),
+								},
+								MinZoom: testLayer2.MinZoom,
+								MaxZoom: testLayer2.MaxZoom,
 							},
 						},
 					},

--- a/server/handle_map_capabilities_test.go
+++ b/server/handle_map_capabilities_test.go
@@ -20,6 +20,7 @@ func TestHandleMapCapabilities(t *testing.T) {
 	testcases := []struct {
 		handler    http.Handler
 		hostName   string
+		port       string
 		uri        string
 		uriPattern string
 		reqMethod  string
@@ -81,6 +82,7 @@ func TestHandleMapCapabilities(t *testing.T) {
 		{
 			handler:    server.HandleCapabilities{},
 			hostName:   "cdn.tegola.io",
+			port:       "none",
 			uri:        "http://localhost:8080/capabilities/test-map.json?debug=true",
 			uriPattern: "/capabilities/:map_name",
 			reqMethod:  "GET",
@@ -161,6 +163,7 @@ func TestHandleMapCapabilities(t *testing.T) {
 		var err error
 
 		server.HostName = test.hostName
+		server.Port = test.port
 
 		//	setup a new router. this handles parsing our URL wildcards (i.e. :map_name, :z, :x, :y)
 		router := httptreemux.New()

--- a/server/server.go
+++ b/server/server.go
@@ -26,8 +26,6 @@ var (
 	Port string
 	//	reference to the version of atlas to work with
 	Atlas *atlas.Atlas
-	//	cache interface to use
-	Cache cache.Interface
 )
 
 //	Start starts the tile server binding to the provided port
@@ -80,19 +78,16 @@ func hostName(r *http.Request) string {
 		log.Printf("Multiple colons (':') in host string: %v", r.Host)
 	}
 
-	var retHost string
-	if HostName != "" {
-		retHost = HostName
-	} else {
+	retHost := HostName
+	if HostName == "" {
 		retHost = requestHostname
 	}
 
-	if Port == "none" {
-		// Don't add a port to the host.
-	} else if Port != "" {
-		retHost += ":" + Port
-	} else if requestPort != "" {
-		retHost += ":" + requestPort
+	if Port != "" && Port != "none" {
+		return retHost + Port
+	}
+	if requestPort != "" && Port != "none" {
+		return retHost + ":" + requestPort
 	}
 
 	return retHost

--- a/server/server_internal_test.go
+++ b/server/server_internal_test.go
@@ -30,7 +30,7 @@ func TestHostName(t *testing.T) {
 		expected string
 	}{
 		{
-			// With hostname port unset in config, expect host:port matching URL
+			// With hostname & port unset in config, expect host:port matching URL
 			request:  mockRequest(urlFromString("http://localhost:8080/capabilities")),
 			expected: "localhost:8080",
 		},

--- a/server/server_internal_test.go
+++ b/server/server_internal_test.go
@@ -3,32 +3,67 @@ package server
 import (
 	"crypto/tls"
 	"net/http"
+	"net/url"
 	"testing"
 )
 
 func TestHostName(t *testing.T) {
+	// Helper function to set up table tests.
+	urlFromString := func(urlString string) *url.URL {
+		url, err := url.Parse(urlString)
+		if err != nil {
+			t.Errorf("Could not create url.URL from %v: %v", urlString, err)
+		}
+		return url
+	}
+
+	// Minimal http.Request with only URL & Host properties set
+	mockRequest := func(u *url.URL) http.Request {
+		r := http.Request{URL: u, Host: u.Host}
+		return r
+	}
+
 	testcases := []struct {
 		request  http.Request
 		hostName string
+		port     string
 		expected string
 	}{
 		{
-			request: http.Request{
-				Host: "localhost",
-			},
-			hostName: "",
-			expected: "localhost",
+			// With hostname port unset in config, expect host:port matching URL
+			request:  mockRequest(urlFromString("http://localhost:8080/capabilities")),
+			expected: "localhost:8080",
 		},
 		{
-			request:  http.Request{},
+			// With hostname set and port set to "none" in config, expect "cdn.tegola.io"
+			request:  mockRequest(urlFromString("http://localhost:8080/capabilities")),
+			hostName: "cdn.tegola.io",
+			port:     "none",
+			expected: "cdn.tegola.io",
+		},
+		{
+			// Hostname set, no port in config, but port in url.  Expect <config_host>:<url_port>.
+			request:  mockRequest(urlFromString("http://localhost:8080/capabilities")),
+			hostName: "cdn.tegola.io",
+			expected: "cdn.tegola.io:8080",
+		},
+		{
+			// Hostname set, no port in config or url, expect hostname to match config.
+			request:  mockRequest(urlFromString("http://localhost/capabilities")),
 			hostName: "cdn.tegola.io",
 			expected: "cdn.tegola.io",
+		},
+		{
+			// Hostname unset, no port in config or url, expect hostname to match url host.
+			request:  mockRequest(urlFromString("http://localhost/capabilities")),
+			expected: "localhost",
 		},
 	}
 
 	for i, tc := range testcases {
 		//	set the package variable
 		HostName = tc.hostName
+		Port = tc.port
 
 		output := hostName(&tc.request)
 		if output != tc.expected {


### PR DESCRIPTION
Changes to server.hostName() to:

1. return <host>:<port> instead of <host>
2. accept ":<port>" or "<port>" from config
