### PR TITLE
Logging interface now has formatting and raw log methods, i.e. Errorf() / Error()

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-MIT License
+MIT License 
 
 Copyright (c) 2016
 

--- a/internal/log/README.md
+++ b/internal/log/README.md
@@ -14,25 +14,28 @@ Logger Proxy API
     Log messages below this level of severity will be ignored.
     Default Log Level is INFO.
 
- * log.Fatal(string, vals... interface{}):
+ * Each of the following also has a formatting string variety; i.e. Fatalf(), Errorf(), etc
+    which behaves the same as fmt.Printf() but outputs to the log instead of stdout.
+
+ * log.Fatal(vals... interface{}):
     prevents the program from continuing
     i.e. can't allocate additional memory
 
- * log.Error(string, vals... interface{}):
+ * log.Error(vals... interface{}):
     non-fatal, but prevents valid execution
     i.e. can't connect to a database, complete a function call, open file, invalid format
 
- * log.Warn(string, vals... interface{}):
+ * log.Warn(vals... interface{}):
     looks unusual, but does not clearly prevent execution
 
- * log.Info(string, vals... interface{}):
+ * log.Info(vals... interface{}):
     Least severe message that a sysadmin would be interested in
     i.e. server request logs
 
- * log.Debug(string, vals... interface{}):
+ * log.Debug(vals... interface{}):
     high level info for a developer. more than what a sysadmin would typically want
 
- * log.Trace(string, vals... interface{}):
+ * log.Trace(vals... interface{}):
     excruciating detail.
 
  * log.SetOutput(io.Writer):

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -5,6 +5,8 @@ import (
 	"sync"
 )
 
+var TimestampRegex string = `\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}` // Ex: "2006-01-02 15:04:05"
+
 type Interface interface {
 	// These all take args the same as calls to fmt.Printf()
 	Fatal(string, ...interface{})

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -1,6 +1,7 @@
 package log
 
 import (
+	"fmt"
 	"io"
 	"sync"
 )
@@ -9,12 +10,12 @@ var TimestampRegex string = `\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}` // Ex: "2006-0
 
 type Interface interface {
 	// These all take args the same as calls to fmt.Printf()
-	Fatal(string, ...interface{})
-	Error(string, ...interface{})
-	Warn(string, ...interface{})
-	Info(string, ...interface{})
-	Debug(string, ...interface{})
-	Trace(string, ...interface{})
+	Fatal(...interface{})
+	Error(...interface{})
+	Warn(...interface{})
+	Info(...interface{})
+	Debug(...interface{})
+	Trace(...interface{})
 	SetOutput(io.Writer)
 }
 
@@ -83,41 +84,86 @@ func SetLogLevel(lvl Level) {
 }
 
 // Output format should be: "timestamp•LOG_LEVEL•filename.go•linenumber•output"
-func Fatal(format string, args ...interface{}) {
-	logger.Fatal(format, args...)
+func Fatalf(format string, args ...interface{}) {
+	msg := fmt.Sprintf(format, args...)
+	logger.Fatal(msg)
 }
 
-func Error(format string, args ...interface{}) {
+func Errorf(format string, args ...interface{}) {
 	if !IsError {
 		return
 	}
-	logger.Error(format, args...)
+	msg := fmt.Sprintf(format, args...)
+	logger.Error(msg)
 }
 
-func Warn(format string, args ...interface{}) {
+func Warnf(format string, args ...interface{}) {
 	if !IsWarn {
 		return
 	}
-	logger.Warn(format, args...)
+	msg := fmt.Sprintf(format, args...)
+	logger.Warn(msg)
 }
 
-func Info(format string, args ...interface{}) {
+func Infof(format string, args ...interface{}) {
 	if !IsInfo {
 		return
 	}
-	logger.Info(format, args...)
+	msg := fmt.Sprintf(format, args...)
+	logger.Info(msg)
 }
 
-func Debug(format string, args ...interface{}) {
+func Debugf(format string, args ...interface{}) {
 	if !IsDebug {
 		return
 	}
-	logger.Debug(format, args...)
+	msg := fmt.Sprintf(format, args...)
+	logger.Debug(msg)
 }
 
-func Trace(format string, args ...interface{}) {
+func Tracef(format string, args ...interface{}) {
 	if !IsTrace {
 		return
 	}
-	logger.Trace(format, args...)
+	msg := fmt.Sprintf(format, args...)
+	logger.Trace(msg)
+}
+
+func Fatal(args ...interface{}) {
+	logger.Fatal(args...)
+}
+
+func Error(args ...interface{}) {
+	if !IsError {
+		return
+	}
+	logger.Error(args...)
+}
+
+func Warn(args ...interface{}) {
+	if !IsWarn {
+		return
+	}
+	logger.Warn(args...)
+}
+
+func Info(args ...interface{}) {
+	if !IsInfo {
+		return
+	}
+	logger.Info(args...)
+}
+
+func Debug(args ...interface{}) {
+	if !IsDebug {
+		return
+	}
+	logger.Debug(args...)
+}
+
+func Trace(args ...interface{}) {
+	if !IsTrace {
+		return
+	}
+	logger.Trace(args...)
 }

--- a/internal/log/log_test.go
+++ b/internal/log/log_test.go
@@ -72,7 +72,7 @@ func TestLogging(t *testing.T) {
 			loggerLevel: INFO,
 			msgLevel:    INFO,
 			msg:         "Hello",
-			expected:    ".*•INFO•.*log_test.go•.*•Hello",
+			expected:    fmt.Sprintf("%v•INFO•.*log_test.go•.*•Hello", TimestampRegex),
 		},
 		// Logging with logger's level set higher than message should result in no output.
 		{
@@ -85,31 +85,31 @@ func TestLogging(t *testing.T) {
 			loggerLevel: TRACE,
 			msgLevel:    TRACE,
 			msg:         "Hello",
-			expected:    ".*•TRACE•.*log_test.go•.*•Hello",
+			expected:    fmt.Sprintf("%v•TRACE•.*log_test.go•.*•Hello", TimestampRegex),
 		},
 		{
 			loggerLevel: TRACE,
 			msgLevel:    DEBUG,
 			msg:         "Hello",
-			expected:    ".*•DEBUG•.*log_test.go•.*•Hello",
+			expected:    fmt.Sprintf("%v•DEBUG•.*log_test.go•.*•Hello", TimestampRegex),
 		},
 		{
 			loggerLevel: TRACE,
 			msgLevel:    INFO,
 			msg:         "Hello",
-			expected:    ".*•INFO•.*log_test.go•.*•Hello",
+			expected:    fmt.Sprintf("%v•INFO•.*log_test.go•.*•Hello", TimestampRegex),
 		},
 		{
 			loggerLevel: TRACE,
 			msgLevel:    WARN,
 			msg:         "Hello",
-			expected:    ".*•WARN•.*log_test.go•.*•Hello",
+			expected:    fmt.Sprintf("%v•WARN•.*log_test.go•.*•Hello", TimestampRegex),
 		},
 		{
 			loggerLevel: TRACE,
 			msgLevel:    ERROR,
 			msg:         "Hello",
-			expected:    ".*•ERROR•.*log_test.go•.*•Hello",
+			expected:    fmt.Sprintf("%v•ERROR•.*log_test.go•.*•Hello", TimestampRegex),
 		},
 		// Check use of formatting args.
 		{
@@ -117,7 +117,7 @@ func TestLogging(t *testing.T) {
 			msgLevel:    ERROR,
 			msg:         "Hello #%v %v",
 			msgArgs:     []interface{}{1, "Joe"},
-			expected:    ".*•ERROR•.*log_test.go•.*•Hello",
+			expected:    fmt.Sprintf("%v•ERROR•.*log_test.go•.*•Hello", TimestampRegex),
 		},
 	}
 

--- a/internal/log/standard.go
+++ b/internal/log/standard.go
@@ -6,6 +6,7 @@ import (
 	goLog "log"
 	"os"
 	"runtime"
+	"time"
 )
 
 var standard Standard
@@ -19,8 +20,9 @@ func (_ Standard) SetOutput(w io.Writer) {
 func Output(level string, format string, args ...interface{}) {
 	logMsg := fmt.Sprintf(format, args...)
 	_, file, line, _ := runtime.Caller(4)
-	// timestamp will be provided by goLog
-	goLog.Printf("•%v•%v•%v•%v", level, file, line, logMsg)
+	timestamp := time.Now().Format("2006-01-02 15:04:05")
+	// "\r" Eliminates the default message prefix so we can format as we like.
+	goLog.Printf("\r%v•%v•%v•%v•%v", timestamp, level, file, line, logMsg)
 }
 
 func (_ Standard) Fatal(format string, args ...interface{}) {

--- a/internal/log/standard.go
+++ b/internal/log/standard.go
@@ -17,35 +17,35 @@ func (_ Standard) SetOutput(w io.Writer) {
 	goLog.SetOutput(w)
 }
 
-func Output(level string, format string, args ...interface{}) {
-	logMsg := fmt.Sprintf(format, args...)
+func Output(level string, args ...interface{}) {
 	_, file, line, _ := runtime.Caller(4)
+	logMsg := fmt.Sprint(args...)
 	timestamp := time.Now().Format("2006-01-02 15:04:05")
 	// "\r" Eliminates the default message prefix so we can format as we like.
 	goLog.Printf("\r%v•%v•%v•%v•%v", timestamp, level, file, line, logMsg)
 }
 
-func (_ Standard) Fatal(format string, args ...interface{}) {
-	Output("FATAL", format, args...)
+func (_ Standard) Fatal(args ...interface{}) {
+	Output("FATAL", args...)
 	os.Exit(1)
 }
 
-func (_ Standard) Error(format string, args ...interface{}) {
-	Output("ERROR", format, args...)
+func (_ Standard) Error(args ...interface{}) {
+	Output("ERROR", args...)
 }
 
-func (_ Standard) Warn(format string, args ...interface{}) {
-	Output("WARN", format, args...)
+func (_ Standard) Warn(args ...interface{}) {
+	Output("WARN", args...)
 }
 
-func (_ Standard) Info(format string, args ...interface{}) {
-	Output("INFO", format, args...)
+func (_ Standard) Info(args ...interface{}) {
+	Output("INFO", args...)
 }
 
-func (_ Standard) Debug(format string, args ...interface{}) {
-	Output("DEBUG", format, args...)
+func (_ Standard) Debug(args ...interface{}) {
+	Output("DEBUG", args...)
 }
 
-func (_ Standard) Trace(format string, args ...interface{}) {
-	Output("TRACE", format, args...)
+func (_ Standard) Trace(args ...interface{}) {
+	Output("TRACE", args...)
 }


### PR DESCRIPTION
Go code regularly uses calls like
```
f, err := os.Open("filename.ext")
if err != nil {
    log.Fatal(err)
}
```

This updates the logger to accept an error var in addition to a string.