### PR TITLE
Update standard log backend to eliminate file:line from timestamp output. (#231)

### DIFF
--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -5,6 +5,8 @@ import (
 	"sync"
 )
 
+var TimestampRegex string = `\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}` // Ex: "2006-01-02 15:04:05"
+
 type Interface interface {
 	// These all take args the same as calls to fmt.Printf()
 	Fatal(string, ...interface{})

--- a/internal/log/log_test.go
+++ b/internal/log/log_test.go
@@ -72,7 +72,7 @@ func TestLogging(t *testing.T) {
 			loggerLevel: INFO,
 			msgLevel:    INFO,
 			msg:         "Hello",
-			expected:    ".*•INFO•.*log_test.go•.*•Hello",
+			expected:    fmt.Sprintf("%v•INFO•.*log_test.go•.*•Hello", TimestampRegex),
 		},
 		// Logging with logger's level set higher than message should result in no output.
 		{
@@ -85,31 +85,31 @@ func TestLogging(t *testing.T) {
 			loggerLevel: TRACE,
 			msgLevel:    TRACE,
 			msg:         "Hello",
-			expected:    ".*•TRACE•.*log_test.go•.*•Hello",
+			expected:    fmt.Sprintf("%v•TRACE•.*log_test.go•.*•Hello", TimestampRegex),
 		},
 		{
 			loggerLevel: TRACE,
 			msgLevel:    DEBUG,
 			msg:         "Hello",
-			expected:    ".*•DEBUG•.*log_test.go•.*•Hello",
+			expected:    fmt.Sprintf("%v•DEBUG•.*log_test.go•.*•Hello", TimestampRegex),
 		},
 		{
 			loggerLevel: TRACE,
 			msgLevel:    INFO,
 			msg:         "Hello",
-			expected:    ".*•INFO•.*log_test.go•.*•Hello",
+			expected:    fmt.Sprintf("%v•INFO•.*log_test.go•.*•Hello", TimestampRegex),
 		},
 		{
 			loggerLevel: TRACE,
 			msgLevel:    WARN,
 			msg:         "Hello",
-			expected:    ".*•WARN•.*log_test.go•.*•Hello",
+			expected:    fmt.Sprintf("%v•WARN•.*log_test.go•.*•Hello", TimestampRegex),
 		},
 		{
 			loggerLevel: TRACE,
 			msgLevel:    ERROR,
 			msg:         "Hello",
-			expected:    ".*•ERROR•.*log_test.go•.*•Hello",
+			expected:    fmt.Sprintf("%v•ERROR•.*log_test.go•.*•Hello", TimestampRegex),
 		},
 		// Check use of formatting args.
 		{
@@ -117,7 +117,7 @@ func TestLogging(t *testing.T) {
 			msgLevel:    ERROR,
 			msg:         "Hello #%v %v",
 			msgArgs:     []interface{}{1, "Joe"},
-			expected:    ".*•ERROR•.*log_test.go•.*•Hello",
+			expected:    fmt.Sprintf("%v•ERROR•.*log_test.go•.*•Hello", TimestampRegex),
 		},
 	}
 

--- a/internal/log/standard.go
+++ b/internal/log/standard.go
@@ -6,6 +6,7 @@ import (
 	goLog "log"
 	"os"
 	"runtime"
+	"time"
 )
 
 var standard Standard
@@ -19,8 +20,9 @@ func (_ Standard) SetOutput(w io.Writer) {
 func Output(level string, format string, args ...interface{}) {
 	logMsg := fmt.Sprintf(format, args...)
 	_, file, line, _ := runtime.Caller(4)
-	// timestamp will be provided by goLog
-	goLog.Printf("•%v•%v•%v•%v", level, file, line, logMsg)
+	timestamp := time.Now().Format("2006-01-02 15:04:05")
+	// "\r" Eliminates the default message prefix so we can format as we like.
+	goLog.Printf("\r%v•%v•%v•%v•%v", timestamp, level, file, line, logMsg)
 }
 
 func (_ Standard) Fatal(format string, args ...interface{}) {


### PR DESCRIPTION
Eliminates default prefix in standard log implementation so output matches expectation.
