### PR TITLE
Issue 244 - Dockerfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: go
+# Does nothing when building on terranodo/tegola, but makes builds work cleanly on forks.
+go_import_path: github.com/terranodo/tegola
 
 go:
   - 1.9.x
@@ -7,11 +9,15 @@ go:
 
 env:
   global:
+  # Secure DOCKER_USER & DOCKER_PASSWORD for user w/ permission to push to repo terranodo/tegola.
+    - secure: "dTdHWSn36tBKls7rM9ayUV7+IBijprmvPqPDWrbjc4XjRAPEW6wZkZ7Ln3qd2GNxe6GTlkAYKogMbqm475aT+s9/d2SqRp0nWlGI7FrAbM7W/v9HEWwjfgdsa1ksChN4zwbmLAeQ4owGnNyQiiE3fe3BzUuWbk6FrKpvhfRjdDAbCiPlt4/YG3rvvs3ePlJsAifCEBJj54ziwg9OThH7Z4TSM/SwhimJLMT60OO7Cqf2jqV7sDnEtttV5i8lSsjk8EACsnfvGtx+SKA7QQMk7OgrW1oNI61jKI3xYALW0JHGdnafIlmizj4NUqKcC9PQbD3pJX6+2b13YWBxNqA9SDk8/0Jwt23XeFvvmxrfYx523VU2XYpq3D/mOgXvWx+LgbjDjQOUwdFoNZ/UGJCPQbD/3uYSDKXIAM8HI3Lzoi2Ej9Xr1wuaPbWPCgQQXoV8KuamJRlkWFLFTUkQ+F2h9aZYHwaZgYmRhDjE3s/QrftLu5fx8uSUULx9Azu4Tj/LB4F3gti7ZXQwlSI0j5BGV7oAMUJq6NAdgOV4Wnz7BQM/oBkfy8ZtOwqUeJUhCwnjnPE6G3Wgo4/9/iCdEg9dRHbuP2/TSxdA0YyLEdXuE8MyE1SqkFoFECNBYWrV2JZV1BN1sGVudxKUeNKfM2FcD0xkx9xPol2x0/hYl3S+Xn8="
     - RUN_POSTGIS_TESTS=yes
     - PGHOST="localhost"
     - PGPORT=5432
     - PGDATABASE="tegola"
     - PGUSER="postgres"
+    - DOCKERHUB_ORG="gospatial"
+    - DOCKERHUB_REPO="tegola"
 
 services:
   - postgresql
@@ -27,9 +33,12 @@ install:
   - bash ci/config_postgis.sh
 
 before_deploy:
+  - docker build -f docker/Dockerfile -t $DOCKERHUB_ORG/$DOCKERHUB_REPO:$TRAVIS_TAG .
+  - docker login -u $DOCKER_USER -p $DOCKER_PASSWORD
+  - docker push $DOCKERHUB_ORG/$DOCKERHUB_REPO:$TRAVIS_TAG
   - go get github.com/mitchellh/gox
-  - cd cmd/tegola/
-  - gox -ldflags "-w -X main.Version=$TRAVIS_TAG" -output "{{.Dir}}_{{.OS}}_{{.Arch}}"
+  - cd cmd/tegola/    # If you change this directory change back so deploy.file finds what it needs
+  - gox -ldflags "-w -X github.com/terranodo/tegola/cmd/tegola/cmd.Version=$TRAVIS_TAG"
 
 deploy:
   provider: releases
@@ -38,7 +47,6 @@ deploy:
   file:
     - "tegola_darwin_386"
     - "tegola_linux_386"
-    - "tegola_netbsd_arm"
     - "tegola_darwin_amd64"
     - "tegola_linux_amd64"
     - "tegola_openbsd_386"
@@ -46,10 +54,8 @@ deploy:
     - "tegola_linux_arm"
     - "tegola_openbsd_amd64"
     - "tegola_freebsd_amd64"
-    - "tegola_netbsd_386"
     - "tegola_windows_386.exe"
     - "tegola_freebsd_arm"
-    - "tegola_netbsd_amd64"
     - "tegola_windows_amd64.exe"
   skip_cleanup: true
   on:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,49 @@
+# To build, run in root of tegola source tree:
+#  1. git clone git@github.com:terranodo/tegola.git or git clone https://github.com/terranodo/tegola.git
+#  2. cd tegola
+#  3. docker build -f docker/Dockerfile -t tegola:0.6.0_beta .
+#
+# To use, add file data sources (i.e. Geopackages) and config as config.toml to a local directory
+# and mount that directory as a volume at /opt/tegola_config/.  PostGIS use only needs the config file.
+#
+# Example gpkg use:
+#  1. mkdir docker-config
+#  2. cp my-config-file docker-config/config.toml
+#  3. cp my-db.gpkg docker-config/
+#  4. update docker-config/config.toml with my-db.gpkg located at /opt/tegola_config/my-db.gpkg
+#  5. docker run -v /path/to/docker-config:/opt/tegola_config -p 8080 tegola:0.6.0_beta
+#
+# Example PostGIS use:
+#  1. mkdir docker-config
+#  2. cp my-config-file docker-config/config.toml
+#  3. docker run -v /path/to/docker-config:/opt/tegola_config -p 8080 tegola:0.6.0_beta
+
+# --- Build the binary
+FROM golang:1.9.2-alpine3.7 AS build
+
+# Only needed for CGO support at time of build, results in no noticable change in binary size
+#  incurs approximately 1:30 extra build time (1:54 vs 0:27) to install packages.  Doesn't impact
+#  development as these layers are drawn from cache after the first build.
+RUN apk update
+RUN apk add musl-dev=1.1.18-r2
+RUN apk add gcc=6.4.0-r5
+
+# Set up source for compilation
+RUN mkdir -p /opt/tegola_src
+COPY . /opt/tegola_src
+RUN rm -rf /opt/tegola_src/src
+RUN mkdir -p /opt/tegola_src/src/github.com/terranodo
+RUN ln -s /opt/tegola_src /opt/tegola_src/src/github.com/terranodo/tegola
+
+# Build binary
+WORKDIR /opt/tegola_src/cmd/tegola
+ENV GOPATH=/opt/tegola_src
+RUN go build -v -gcflags "-N -l" -o /opt/tegola
+RUN chmod a+x /opt/tegola
+
+# --- Create minimal deployment image, just alpine & the binary
+FROM alpine:3.7
+LABEL maintainer="Development@JivanAmara.net"
+LABEL io.terranodo.version="0.6.0_beta"
+COPY --from=build /opt/tegola /opt/
+CMD ["/opt/tegola", "--config", "/opt/tegola_config/config.toml", "serve"]


### PR DESCRIPTION
Adds a Dockerfile for building a binary and creating a minimal deployment image using the alpine docker image as a base.

Using static linking, cgo support is included, entirely encapsulated in the binary with trivial difference to binary size.  Since it isn't affecting dependencies or binary/image size I think we should reconsider separating pure go & cgo-support docker images.
