### PR TITLE
Issue 250 - tile cache response writer - catch non 200 response

### DIFF
--- a/server/middleware_tile_cache.go
+++ b/server/middleware_tile_cache.go
@@ -54,6 +54,11 @@ func TileCacheHandler(next http.Handler) http.Handler {
 				return
 			}
 
+			//	if nothing has been written to the buffer, don't write to the cache
+			if buff.Len() == 0 {
+				return
+			}
+
 			if err := cacher.Set(key, buff.Bytes()); err != nil {
 				log.Printf("cache response writer err: %v", err)
 			}
@@ -85,8 +90,10 @@ func newTileCacheResponseWriter(resp http.ResponseWriter, w io.Writer) http.Resp
 //	tileCacheResponsWriter wraps http.ResponseWriter (https://golang.org/pkg/net/http/#ResponseWriter)
 //	to additionally write the response to a cache when there is a cache MISS
 type tileCacheResponseWriter struct {
-	resp  http.ResponseWriter
-	multi io.Writer
+	//	status response code
+	status int
+	resp   http.ResponseWriter
+	multi  io.Writer
 }
 
 func (w *tileCacheResponseWriter) Header() http.Header {
@@ -97,10 +104,18 @@ func (w *tileCacheResponseWriter) Header() http.Header {
 }
 
 func (w *tileCacheResponseWriter) Write(b []byte) (int, error) {
-	//	write to our multi writer
-	return w.multi.Write(b)
+	//	only write to the multi writer when http response == StatusOK
+	if w.status == http.StatusOK {
+		//	write to our multi writer
+		return w.multi.Write(b)
+	}
+
+	//	write to the original response writer
+	return w.resp.Write(b)
 }
 
 func (w *tileCacheResponseWriter) WriteHeader(i int) {
+	w.status = i
+
 	w.resp.WriteHeader(i)
 }

--- a/server/middleware_tile_cache_internal_test.go
+++ b/server/middleware_tile_cache_internal_test.go
@@ -1,0 +1,50 @@
+package server
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+)
+
+func TestTileCacheResponseWriter(t *testing.T) {
+	testcases := []struct {
+		data         []byte
+		responseCode int
+		expected     []byte
+	}{
+		{
+			data:         []byte{0x53, 0x69, 0x6c, 0x61, 0x73},
+			responseCode: http.StatusOK,
+			expected:     []byte{0x53, 0x69, 0x6c, 0x61, 0x73},
+		},
+		{
+			data:         []byte{0x53, 0x69, 0x6c, 0x61, 0x73},
+			responseCode: http.StatusInternalServerError,
+			expected:     []byte{},
+		},
+	}
+
+	for i, tc := range testcases {
+		var buff bytes.Buffer
+
+		rw := newTileCacheResponseWriter(httptest.NewRecorder(), &buff)
+		rw.WriteHeader(tc.responseCode)
+		_, err := rw.Write(tc.data)
+		if err != nil {
+			t.Errorf("[%v] unable to write to response writer: %v", i, err)
+			continue
+		}
+
+		if buff.Len() != len(tc.expected) {
+			t.Errorf("[%v] expected (%v) does not match output (%v)", i, tc.expected, buff.Bytes())
+			continue
+		}
+
+		if len(tc.expected) > 0 && !reflect.DeepEqual(buff.Bytes(), tc.expected) {
+			t.Errorf("[%v] expected (%v) does not match output (%v)", i, tc.expected, buff.Bytes())
+			return
+		}
+	}
+}


### PR DESCRIPTION
The tile cache middleware was writing to the cache on any response. This patch checks for http 200 status codes before writing to the cache. 