### PR TITLE
V0.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ go:
 
 env:
   global:
-  # Secure DOCKER_USER & DOCKER_PASSWORD for user w/ permission to push to repo gospatial/tegola.
+    # Secure DOCKER_USER & DOCKER_PASSWORD for user w/ permission to push to repo gospatial/tegola.
     - secure: "dTdHWSn36tBKls7rM9ayUV7+IBijprmvPqPDWrbjc4XjRAPEW6wZkZ7Ln3qd2GNxe6GTlkAYKogMbqm475aT+s9/d2SqRp0nWlGI7FrAbM7W/v9HEWwjfgdsa1ksChN4zwbmLAeQ4owGnNyQiiE3fe3BzUuWbk6FrKpvhfRjdDAbCiPlt4/YG3rvvs3ePlJsAifCEBJj54ziwg9OThH7Z4TSM/SwhimJLMT60OO7Cqf2jqV7sDnEtttV5i8lSsjk8EACsnfvGtx+SKA7QQMk7OgrW1oNI61jKI3xYALW0JHGdnafIlmizj4NUqKcC9PQbD3pJX6+2b13YWBxNqA9SDk8/0Jwt23XeFvvmxrfYx523VU2XYpq3D/mOgXvWx+LgbjDjQOUwdFoNZ/UGJCPQbD/3uYSDKXIAM8HI3Lzoi2Ej9Xr1wuaPbWPCgQQXoV8KuamJRlkWFLFTUkQ+F2h9aZYHwaZgYmRhDjE3s/QrftLu5fx8uSUULx9Azu4Tj/LB4F3gti7ZXQwlSI0j5BGV7oAMUJq6NAdgOV4Wnz7BQM/oBkfy8ZtOwqUeJUhCwnjnPE6G3Wgo4/9/iCdEg9dRHbuP2/TSxdA0YyLEdXuE8MyE1SqkFoFECNBYWrV2JZV1BN1sGVudxKUeNKfM2FcD0xkx9xPol2x0/hYl3S+Xn8="
     - RUN_POSTGIS_TESTS=yes
     - PGHOST="localhost"
@@ -18,6 +18,8 @@ env:
     - PGUSER="postgres"
     - DOCKERHUB_ORG="gospatial"
     - DOCKERHUB_REPO="tegola"
+    # "COVERALLS_TOKEN" nvp encrypted using travis CLI - contains api key used to post test coverage results to coveralls.io account repo associated w/ github repo - note that this must be regenerated against official tegola repo since it was originally generated against my tegola github fork
+    - secure: Mo8VnGNYL6BKmtcLNcR9lvQuelqs06kvTVq3WIsG8KsjVp+ql6ZEPlhvqdtMfsc7KE69xOpHJA8n6pGJz5PwgUukEmOD32ZjPs0ipdTzFD+DMfaKeKMTKpeUeKqTa2eOhmBsNAv/pWlkEqhwJsKeEH/1DSIblam04HUhpkpSDzS1HJv78bH4YTQlEpkgbkewpGJduG6g2Y9y6J3dr5JAtLYWVsgbbjNJfRw4y/TdxAdZEjWWI2bXVFI/yEHHTiF4y7JOPOyWCy5jmSDimiUnqZGEDWUiLnUHMFyLudVhR9ZkpyMpD46+vjE6SpeMiIhdLAXiRevHUTgJ4sQWbotCkD8HAWzM5sbu+c9UTsS2LyeWEtIGGV/0xM9wrMK+5sBrPec2BR8TE8Kml2SNLTkoT+scphXfmgFx55/61t7eJZu7ysOzUAPRfSf5Ukpwb16Z1KLpXEVG6jfqwR9cfyVfNQzD0ERY33SMitONwPY0ViW3J2yK0djrjA16MKFHRqTyM6Q2H8wcVnFZGVpMLkdpRJlVoOoEn5INXJ4pqsDb+q+95MTUV9GnJRLspOaCb54du6iduJ89H1QbersQNMFGinBz/WR8ZP0pRIzVzxo3oo/9LcVZALPnyQqNLrdZhxr5r9UYmh33NQBK/S3cHARI7rpOQXAI0shWZhGNA8NV1C4=
 
 services:
   - postgresql
@@ -32,6 +34,15 @@ install:
   - bash ci/build_bindata.sh
   - bash ci/config_postgis.sh
 
+# "script" phase occurs after "install" and before "deploy" phases (and sub-phases) - see https://docs.travis-ci.com/user/customizing-the-build/#The-Build-Lifecycle
+#   by default, in absence of "script" phase, travis go build executes "go test -v ./..." - see https://docs.travis-ci.com/user/languages/go/#Default-Build-Script
+#   which we replace below since we want to execute "go test" against multiple packages while generating a cover profile for each - "go test" does not currently
+#   support this, so we use custom script go_test_multi_package_coverprofile.sh to do so... this script also aggregates generated cover profiles into a single
+#   coverage profile and then finally posts the results to the coveralls.io acccount/repo associated with the encrypted API key/token above - see "COVERALLS_TOKEN"
+#   in env|global section, above
+script:
+  - bash ci/go_test_multi_package_coverprofile.sh --coveralls
+
 before_deploy:
   - docker build -f docker/Dockerfile -t $DOCKERHUB_ORG/$DOCKERHUB_REPO:$TRAVIS_TAG .
   - docker tag $DOCKERHUB_ORG/$DOCKERHUB_REPO:$TRAVIS_TAG $DOCKERHUB_ORG/$DOCKERHUB_REPO:latest
@@ -40,29 +51,32 @@ before_deploy:
   - docker push $DOCKERHUB_ORG/$DOCKERHUB_REPO:latest
   - go get github.com/mitchellh/gox
   - cd cmd/tegola/    # If you change this directory change back so deploy.file finds what it needs
-  - gox -ldflags "-w -X github.com/terranodo/tegola/cmd/tegola/cmd.Version=$TRAVIS_TAG"
+  - gox -ldflags "-w -X github.com/terranodo/tegola/cmd/tegola/cmd.Version=$TRAVIS_TAG" -output "{{.Dir}}_{{.OS}}_{{.Arch}}"
 
 deploy:
   provider: releases
   api_key:
     secure: GrkTzVjddIHB8MXfLloPgifJKrZuFptk9DzrrSSXAOxxBBqYnddg2WKAr2TfrPLQaSNdR84PaPN3FXW009W/CjclxM3mW9h9a/sFVlWtWOWd5u/szFPwn5JQKKt0D/EhScBUF9Jvyo4g28YxSR9rV/RnJne/B6pthJAFSrztHglC7XGkW9mSTH7aG68yIALoGeqHRIKT3DDHJPCm14EEXKq8oacJSX6SZyexBcBJRKj8S+/k3HoYDeKqvCC8oPHt1kPHXiSF/mZdeox0CQ+Q9B3cWPu6rFNbOjiLQriq9ayY/DxdZPVHdQ/nFkTpBQ3lwDLFL4X2jcT1V0jvNxJnExJOXV9lFtjvyExqr7quGHTMd4iJVeYOkWwEl8/cJJAoePIlKaGL5FDxLhlq1RscHOu25sd1DgmbhJMjlexxG/bXyJhV873kyv6JhIq+XniA2TxpaMMrut8MOBH76THbQr9yWpdf6GXs7NdRiK8yzS+L/hvXJO88NXegavCk8gGtWhHSLSJzYg5fVIo9QdghfRe8cLj2HcMehwzLyu3GRiWdm8TtNQ+PIp9qXxB+BIOfXN+Dx1ydVdlt8aghefONw9+0zDtrGZhWyORMHBCypXrTEmiGxlIfsR4QQxVpejd8DXi3i9CQou68ECuC51YqxhH49tfiE8Adh0WPKCklRnY=
   file:
-    - "tegola_darwin_386"
-    - "tegola_linux_386"
-    - "tegola_darwin_amd64"
-    - "tegola_linux_amd64"
-    - "tegola_openbsd_386"
-    - "tegola_freebsd_386"
-    - "tegola_linux_arm"
-    - "tegola_openbsd_amd64"
-    - "tegola_freebsd_amd64"
-    - "tegola_windows_386.exe"
-    - "tegola_freebsd_arm"
-    - "tegola_windows_amd64.exe"
+    - tegola_darwin_386
+    - tegola_linux_386
+    - tegola_netbsd_arm
+    - tegola_darwin_amd64
+    - tegola_linux_amd64
+    - tegola_openbsd_386
+    - tegola_freebsd_386
+    - tegola_linux_arm
+    - tegola_openbsd_amd64
+    - tegola_freebsd_amd64
+    - tegola_netbsd_386
+    - tegola_windows_386.exe
+    - tegola_freebsd_arm
+    - tegola_netbsd_amd64
+    - tegola_windows_amd64.exe
   skip_cleanup: true
   on:
     tags: true
-    condition: $TRAVIS_GO_VERSION =~ ^1\.9\.[0-9]+$
+    condition: "$TRAVIS_GO_VERSION =~ ^1\\.9\\.[0-9]+$"
 
 notifications:
   email:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build Status](https://travis-ci.org/terranodo/tegola.svg?branch=master)](https://travis-ci.org/terranodo/tegola)
 [![Report Card](https://goreportcard.com/badge/github.com/terranodo/tegola)](https://goreportcard.com/badge/github.com/terranodo/tegola)
+[![Coverage Status](https://coveralls.io/repos/github/sacontreras/tegola/badge.svg)](https://coveralls.io/github/sacontreras/tegola)
 [![Godoc](http://img.shields.io/badge/godoc-reference-blue.svg?style=flat)](https://godoc.org/github.com/terranodo/tegola)
 [![license](http://img.shields.io/badge/license-MIT-red.svg?style=flat)](https://github.com/terranodo/tegola/blob/master/LICENSE.md)
 
@@ -52,7 +53,7 @@ Use "tegola [command] --help" for more information about a command.
 /
 ```
 
-The server root will display a built in viewer with an auto generated style. For example: 
+The server root will display a built in viewer with an auto generated style. For example:
 
 ![tegola built in viewer](https://raw.githubusercontent.com/terranodo/tegola/v0.4.0/docs/screenshots/built-in-viewer.png "tegola built in viewer")
 

--- a/ci/go_test_multi_package_coverprofile.sh
+++ b/ci/go_test_multi_package_coverprofile.sh
@@ -1,0 +1,103 @@
+#!/bin/sh
+# Generate test coverage statistics for Go packages.
+#
+# Works around the fact that `go test -coverprofile` currently does not work
+# with multiple packages, see https://code.google.com/p/go/issues/detail?id=6909
+#
+# Usage: go_test_multi_package_coverprofile --coverprofilename=<coverprofile base filename> [--html] [--coveralls]
+#
+#     --coverprofilename  basefilename for coverprofile data
+#     --html              Additionally create HTML report <coverprofile base filename>.html
+#     --coveralls         Push coverage statistics to coveralls.io
+#
+#
+# S.C. - borrowed/adapted from https://github.com/mlafeldt/chef-runner/blob/v0.7.0/script/coverage; see also https://mlafeldt.github.io/blog/test-coverage-in-go/
+
+set -e
+
+workdir=.cover
+coverprofilename=default
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --coverprofilename=*)
+      coverprofilename="${1#*=}"
+      ;;
+    --html)
+      genhtml=true
+      ;;
+    --coveralls)
+      pushtocoveralls=true
+      ;;
+    *)
+      printf "\tError: Invalid argument \"$1\"\n"
+      exit 1
+  esac
+  shift
+done
+
+coverprofile="$workdir/$coverprofilename.coverprofile"
+
+# from official go test docs:
+#           -covermode set,count,atomic
+#            Set the mode for coverage analysis for the package[s]
+#            being tested. The default is "set" unless -race is enabled,
+#            in which case it is "atomic".
+#            The values:
+#                set: bool: does this statement run?
+#                count: int: how many times does this statement run?
+#                atomic: int: count, but correct in multithreaded tests;
+#                        significantly more expensive.
+#            Sets -cover.
+mode=count
+
+
+
+# functions section
+generate_cover_data() {
+    rm -rf "$workdir"
+    mkdir "$workdir"
+
+    for pkg in "$@"; do
+        f="$workdir/$(echo $pkg | tr / -).pkgcoverprofile"
+        go test -covermode="$mode" -coverprofile="$f" "$pkg"
+    done
+
+    echo "mode: $mode" > "$coverprofile"
+    grep -h -v "^mode:" "$workdir"/*.pkgcoverprofile >> "$coverprofile"
+}
+
+generate_cover_report() {
+    case ${1} in
+      html)
+        go tool cover -html="$coverprofile" -o "$coverprofilename".coverprofile.html
+        ;;
+      func)
+        go tool cover -func="$coverprofile"
+        ;;
+      *)
+        echo >&2 "error: generate_cover_report invalid arg: $1"
+        exit 1
+        ;;
+    esac
+}
+
+push_to_coveralls() {
+    echo "Pushing coverage statistics to coveralls.io"
+    goveralls -coverprofile="$coverprofile"
+}
+
+
+
+# body of script
+  # first get go cover tool in case it does not exist locally
+go get golang.org/x/tools/cmd/cover
+generate_cover_data $(go list ./...)
+generate_cover_report func
+if [ "$genhtml" = true ] ; then
+    generate_cover_report html
+fi
+if [ "$pushtocoveralls" = true ] ; then
+    go get github.com/mattn/goveralls
+    push_to_coveralls
+fi


### PR DESCRIPTION
The following steps must be completed in order to post test coverage results to coveralls.io:

1. enable terranodo/tegola repo at coveralls.io for official terranodo/tegola coveralls.io account, at https://coveralls.io/repos/new while logged into this account
2. generate/replace encrypted coveralls api key/token ```secure``` line (line 22) in global env vars in `travis.yml` for terranodo/tegola - please note that there are currently two encrypted environment variable lines... replace the second one, NOT the first
    1. at https://coveralls.io/repos/new, while logged into terranodo/tegola coveralls.io account, click "DETAILS" for enabled terranodo/tegola repo, copy value from "TOKEN" section
    2. on local machine, with terranodo/tegola repo checked out, execute shell command ```travis encrypt COVERALLS_TOKEN=<token value from step 2.i>``` - requires travis CLI to be installed locally - see https://github.com/travis-ci/travis.rb#installation
    3. this produces shell output similar to
 ```secure: "t+LjZbhH4EK/u+WU4H23wRIBO6Jk2abko+COW5YNsCjEaR4bSewxbG2hXSQqrPXM6Vgk49T1J2iA2pUNzgkBgTZp0oeYr3sTD0IrVzkQWs+UdtX7U9I..."``` 
    4. replace existing ```secure``` line (line 22) in travis.yml with line copied (from beginning of "secure" to terminating double-quote) from shell, step 2.iii
3. replace coveralls "Coverage Status" badge (line 5) in readme.md with https://coveralls.io/repos/new | "DETAILS" | "EMBED" | "MARKDOWN" value while logged into coveralls.io official terranodo/tegola account


Additional notes:
- by default, in the absence of the ```script``` block w/in travis.yml, travis CI executes ```go test -v ./...``` - see https://docs.travis-ci.com/user/languages/go/#Default-Build-Script - and this does NOT produce coverage results from instrumentation produced by the ```go test``` build
- to override, ```script``` block must be added to add additional options to ```go test``` command, or to do something else entirely in lieu of default ```go test -v ./...``` command
- ```go test``` command does NOT support multiple packages... go_test_multi_package_coverprofile.sh (adapted from https://github.com/mlafeldt/chef-runner/blob/v0.7.0/script/coverage) works around this, by looping through each package, producing coverage results, then aggregating each one into a final, single coverage result, which is then posted to coveralls