### PR TITLE
[issue-280] 2pt lines were being disgarded.

### DIFF
--- a/mvt/feature.go
+++ b/mvt/feature.go
@@ -398,7 +398,7 @@ func (c *cursor) scalelinestr(g tegola.LineString) (ls basic.Line) {
 
 	pts := g.Subpoints()
 	// If the linestring
-	if len(pts) < 3 {
+	if len(pts) < 2 {
 		// Not enought points to make a line.
 		return nil
 	}
@@ -414,7 +414,8 @@ func (c *cursor) scalelinestr(g tegola.LineString) (ls basic.Line) {
 		ls = append(ls, npt)
 		lidx = len(ls) - 1
 	}
-	if len(ls) < 3 {
+
+	if len(ls) < 2 {
 		// Not enough points. the zoom must be too far out for this ring.
 		return nil
 	}


### PR DESCRIPTION
A check that if a line had only 1 or fewer points was
check if a line had 2 or few points to disgard. This
will no longer happen.

fixed #280