### PR TITLE
Issue 290 panic idx out of range

### DIFF
--- a/atlas/map.go
+++ b/atlas/map.go
@@ -177,7 +177,7 @@ func (m Map) Encode(ctx context.Context, tile *slippy.Tile) ([]byte, error) {
 					z, x, y := tile.ZXY()
 					// TODO (arolek): should we return an error to the response or just log the error?
 					// we can't just write to the response as the waitgroup is going to write to the response as well
-					log.Printf("Error Getting MVTLayer for tile Z: %v, X: %v, Y: %v: %v", z, x, y, err)
+					log.Printf("err fetching tile (z: %v, x: %v, y: %v) features: %v", z, x, y, err)
 				}
 				return
 			}

--- a/maths/clip/clip.go
+++ b/maths/clip/clip.go
@@ -10,6 +10,9 @@ import (
 
 func LineString(linestr tegola.LineString, extent *points.Extent) (ls []basic.Line, err error) {
 	line := lines.FromTLineString(linestr)
+	if len(line) == 0 {
+		return ls, nil
+	}
 
 	var cpts [][2]float64
 	lptIsIn := extent.Contains(line[0])

--- a/maths/clip/linestring_test.go
+++ b/maths/clip/linestring_test.go
@@ -189,6 +189,10 @@ func TestLineString(t *testing.T) {
 				basic.NewLine(144.397830, 4096, 0, 3901.712895),
 			},
 		},
+		"empty line": tcase{
+			extent:  &testExtents[11],
+			linestr: basic.Line{},
+		},
 	}
 	for name, tc := range tests {
 		tc := tc


### PR DESCRIPTION
Fixes #290 range panic.

#290 identifies a panic in the clipping of a linestring. 