### PR TITLE
Replace all occurances of ST_AsBinary when checking types

### DIFF
--- a/provider/postgis/postgis.go
+++ b/provider/postgis/postgis.go
@@ -272,7 +272,7 @@ func (p Provider) layerGeomType(l *Layer) error {
 
 	//	we want to know the geom type instead of returning the geom data so we modify the SQL
 	//	TODO: this strategy wont work if remove the requirement of wrapping ST_AsBinary(geom) in the SQL statements.
-	sql = strings.Replace(strings.ToLower(sql), "st_asbinary", "st_geometrytype", 1)
+	sql = strings.Replace(strings.ToLower(sql), "st_asbinary", "st_geometrytype", -1)
 
 	//	we only need a single result set to sniff out the geometry type
 	sql = fmt.Sprintf("%v LIMIT 1", sql)


### PR DESCRIPTION
There are issues with checking types using ST_GeometryType that this doesn't fix, but this does fix the issue of UNIONed tables and mixed types.

In addition to this applying to 0.5.x, it should be backported to 0.4.x, where the regression was introduced.

It fixes the **specific** error in #320 but that one should be left open or a new issue created about the problems of relying on string replacement like this.