### PR TITLE
configurable layer simplification #165

### DIFF
--- a/atlas/layer.go
+++ b/atlas/layer.go
@@ -16,6 +16,9 @@ type Layer struct {
 	//	default tags to include when encoding the layer. provider tags take precedence
 	DefaultTags map[string]interface{}
 	GeomType    geom.Geometry
+	//	DontSimplify indicates wheather feature simplification should be applied.
+	//	We use a negative in the name so the default is to simplify
+	DontSimplify bool
 }
 
 //	MVTName will return the value that will be encoded in the Name field when the layer is encoded as MVT

--- a/atlas/map.go
+++ b/atlas/map.go
@@ -141,8 +141,10 @@ func (m Map) Encode(ctx context.Context, tile *slippy.Tile) ([]byte, error) {
 
 		// go routine for fetching the layer concurrently
 		go func(i int, l Layer) {
-			var mvtLayer mvt.Layer
-			mvtLayer.Name = l.MVTName()
+			mvtLayer := mvt.Layer{
+				Name:         l.MVTName(),
+				DontSimplify: l.DontSimplify,
+			}
 
 			// on completion let the wait group know
 			defer wg.Done()

--- a/cmd/tegola/cmd/root.go
+++ b/cmd/tegola/cmd/root.go
@@ -178,6 +178,7 @@ func initMaps(maps []config.Map, providers map[string]provider.Tiler) error {
 				Provider:          provider,
 				DefaultTags:       defaultTags,
 				GeomType:          layerGeomType,
+				DontSimplify:      l.DontSimplify,
 			})
 		}
 

--- a/config/config.go
+++ b/config/config.go
@@ -37,8 +37,6 @@ type Config struct {
 type Webserver struct {
 	HostName          string `toml:"hostname"`
 	Port              string `toml:"port"`
-	LogFile           string `toml:"log_file"`
-	LogFormat         string `toml:"log_format"`
 	CORSAllowedOrigin string `toml:"cors_allowed_origin"`
 }
 
@@ -59,6 +57,9 @@ type MapLayer struct {
 	MinZoom       int         `toml:"min_zoom"`
 	MaxZoom       int         `toml:"max_zoom"`
 	DefaultTags   interface{} `toml:"default_tags"`
+	//	DontSimplify indicates wheather feature simplification should be applied.
+	//	We use a negative in the name so the default is to simplify
+	DontSimplify bool `toml:"dont_simplify"`
 }
 
 //	checks the config for issues


### PR DESCRIPTION
- plubmed through layer simplification control to the tegola config
- updated config Parse and Validate tests to use new format
- removed log_format and log_file config artifacts (#255)