### PR TITLE
simplify sort+unique functions

### DIFF
--- a/maths/makevalid/makevalid.go
+++ b/maths/makevalid/makevalid.go
@@ -9,10 +9,12 @@ import (
 	"github.com/terranodo/tegola/maths/points"
 )
 
-func allCoordForPts(idx int, pts ...[2]float64) (fs []float64) {
+func allCoordForPts(idx int, pts ...[2]float64) []float64 {
 	if idx != 0 && idx != 1 {
 		panic("idx can only be 0 or 1 for x, and y")
 	}
+
+	fs := make([]float64, 0, len(pts))
 	for i := range pts {
 		fs = append(fs, pts[i][idx])
 	}
@@ -20,27 +22,22 @@ func allCoordForPts(idx int, pts ...[2]float64) (fs []float64) {
 }
 
 func sortUniqueF64(fs []float64) []float64 {
+	if len(fs) == 0 {
+		return fs
+	}
+
 	sort.Float64s(fs)
-	lf := 0
-	fslen := len(fs)
-	for i := 1; i < fslen; i++ {
-		if fs[i] == fs[lf] {
+	count := 0
+	for i := range fs {
+		if fs[count] == fs[i] {
 			continue
 		}
-		lf += 1
-		if lf == i {
-			continue
-		}
-		// found something that is not the same.
-		copy(fs[lf:], fs[i:])
-		fslen -= (i - lf)
-		i = lf
+
+		count++
+		fs[count] = fs[i]
 	}
-	if fslen > lf+1 {
-		// Need to copy things over, and adjust the fslen
-		return fs[:lf+1]
-	}
-	return fs[:fslen]
+
+	return fs[:count+1]
 }
 
 // splitPoints will find the points amount the lines that lines should be split at.

--- a/maths/points/sorted.go
+++ b/maths/points/sorted.go
@@ -6,27 +6,24 @@ import (
 	"github.com/terranodo/tegola/maths"
 )
 
+// SortAndUnique sorts the points using the X first then Y ordering
+// and removes duplicates.
 func SortAndUnique(pts []maths.Pt) []maths.Pt {
+	if len(pts) == 0 {
+		return pts
+	}
+
 	sort.Sort(ByXY(pts))
-	lp := 0
-	ptslen := len(pts)
-	for i := 1; i < ptslen; i++ {
-		if pts[i].IsEqual(pts[lp]) {
+
+	count := 0
+	for i := range pts {
+		if pts[count].IsEqual(pts[i]) {
 			continue
 		}
-		lp += 1
-		if lp == i {
-			continue
-		}
-		// found something that is not the same.
-		copy(pts[lp:], pts[i:])
-		// Adjust the length.
-		ptslen -= (i - lp)
-		i = lp
+
+		count++
+		pts[count] = pts[i]
 	}
-	if ptslen > lp+1 {
-		// Need to copy things over, and adjust the ptslen
-		return pts[:lp+1]
-	}
-	return pts[:ptslen]
+
+	return pts[:count+1]
 }

--- a/maths/points/sorted_test.go
+++ b/maths/points/sorted_test.go
@@ -35,6 +35,10 @@ func TestSortAndUnique(t *testing.T) {
 			spts:  []maths.Pt{{1, 2}},
 		},
 		tcase{
+			uspts: []maths.Pt{{1, 2}, {1, 2}, {3, 4}, {5, 6}, {5, 6}},
+			spts:  []maths.Pt{{1, 2}, {3, 4}, {5, 6}},
+		},
+		tcase{
 			uspts: []maths.Pt{{7, 8}, {1, 2}, {3, 4}, {5, 6}, {3, 4}, {1, 2}, {7, 8}, {2, 3}, {1, 2}},
 			spts:  []maths.Pt{{1, 2}, {2, 3}, {3, 4}, {5, 6}, {7, 8}},
 		},


### PR DESCRIPTION
previously, the "find unique" part of these functions would shift everything down when it found unique value(s). This has a worst case runtime of O(n^2). New approach shifts down as you go, O(n). 

While this will probably have little impact on real world performance I found the old version difficult to follow with the 2 extra if conditions.

benchmarks are with 400ish floats, the sort is included as part of the benchmarks:

```
benchmark                              old ns/op     new ns/op     delta
BenchmarkSortUniqueF64-4               16916         15703         -7.17%
BenchmarkSortUniqueF64_worstCase-4     20154         14002         -30.52%
```